### PR TITLE
Send INTERACT_AT before INTERACT when clicking on villager

### DIFF
--- a/src/main/java/maxsuperman/addons/roller/modules/VillagerRoller.java
+++ b/src/main/java/maxsuperman/addons/roller/modules/VillagerRoller.java
@@ -37,7 +37,9 @@ import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.ItemEnchantmentsComponent;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.entity.projectile.ProjectileUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
@@ -50,7 +52,9 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.village.TradeOffer;
 import net.minecraft.village.TradeOfferList;
 import net.minecraft.village.VillagerProfession;
@@ -517,6 +521,14 @@ public class VillagerRoller extends Module {
         if (pauseOnScreen.get() && mc.currentScreen != null) {
             info("Rolling paused, interact with villager to continue");
         } else {
+            Vec3d playerPos = mc.player.getEyePos();
+            Vec3d villagerPos = rollingVillager.getEyePos();
+            EntityHitResult entityHitResult = ProjectileUtil.raycast(mc.player, playerPos, villagerPos, rollingVillager.getBoundingBox(), Entity::canHit, playerPos.squaredDistanceTo(villagerPos));
+            if (entityHitResult == null) {
+                warning("Raycast didn't find villager entity?");
+                return;
+            }
+            mc.interactionManager.interactEntityAtLocation(mc.player, rollingVillager, entityHitResult, Hand.MAIN_HAND);
             mc.interactionManager.interactEntity(mc.player, rollingVillager, Hand.MAIN_HAND);
         }
     }


### PR DESCRIPTION
This matches the behavior of the vanilla client and fixes #37.

The relevant code (in `MinecraftClient::doItemUse`) looks like this:

```
if (this.crosshairTarget != null) {
    switch(this.crosshairTarget.getType()) {
        case ENTITY:
            EntityHitResult entityHitResult = (EntityHitResult)this.crosshairTarget;
            Entity entity = entityHitResult.getEntity();
            if (!this.world.getWorldBorder().contains(entity.getBlockPos())) {
                return;
            }

            ActionResult actionResult = this.interactionManager.interactEntityAtLocation(this.player, entity, entityHitResult, hand);
            if (!actionResult.isAccepted()) {
                actionResult = this.interactionManager.interactEntity(this.player, entity, hand);
            }

            [...]
```

`ArmorStandEntity` is the only entity that returns anything other than `ActionResult.PASS` from `Entity::interactAt`, but `ClientPlayerInteractionManager::interactEntityAtLocation` sends the `INTERACT_AT` packet before calling `Entity::interactAt`. So unless dealing with an armor stand, `actionResult.isAccepted()` always returns false, and the client ends up sending both INTERACT_AT and INTERACT packets. I guess 2b's anticheat decided to use this to check entity interactions more strictly.

Side note: `interact-delay` definitely isn't the right branch to merge into, but I'm using this with a 1.20.6 client and I suspect that others might be in the same boat (for at least a little while), so only including this in the 1.21 build would be a shame. Not sure how you would prefer to deal with that, but this code should work on either version.