### PR TITLE
add support for 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Fabric (https://fabricmc.net/versions.html)
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.2
 loader_version=0.16.9
 
 # Mod Properties


### PR DESCRIPTION
just changed some values to support 1.21.4, but this going to be draft because meteor support for 1.21.4 pull request is still a draft. after all it compiles just fine, but still going to test in-case of crashes.

https://github.com/MeteorDevelopment/meteor-client/pull/5030
